### PR TITLE
✨ (spring-3-upgrade): Upgrade spring deps to version 3.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compile("au.com.console:kotlin-jpa-specification-dsl:2.0.0")
+    compile("au.com.console:kotlin-jpa-specification-dsl:3.0.0")
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.6.21'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
 group 'au.com.console'
@@ -10,16 +10,16 @@ repositories {
     gradlePluginPortal()
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 dependencies {
     api 'org.jetbrains.kotlin:kotlin-reflect'
-    api 'org.springframework.data:spring-data-jpa:2.3.0.RELEASE'
-    compileOnly 'jakarta.persistence:jakarta.persistence-api:2.2.3'
-    testApi 'org.springframework.boot:spring-boot-starter-data-jpa:2.3.0.RELEASE'
+    api 'org.springframework.data:spring-data-jpa:3.0.9'
+    compileOnly 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    testApi 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.9'
     testApi 'com.h2database:h2:1.4.191'
-    testApi 'org.springframework.boot:spring-boot-starter-test:2.3.0.RELEASE'
+    testApi 'org.springframework.boot:spring-boot-starter-test:3.0.9'
     testApi 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
 }
@@ -34,12 +34,12 @@ test {
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
         freeCompilerArgs = ["-Xinline-classes"]
     }
 }
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }

--- a/src/main/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSL.kt
+++ b/src/main/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSL.kt
@@ -1,7 +1,7 @@
 package au.com.console.jpaspecificationdsl
 
 import org.springframework.data.jpa.domain.Specification
-import javax.persistence.criteria.*
+import jakarta.persistence.criteria.*
 import kotlin.reflect.KProperty1
 
 // Helper to allow joining to Properties
@@ -26,7 +26,7 @@ fun <T, R> KProperty1<T, R?>.notEqual(x: R): Specification<T> = spec { notEqual(
 // Ignores empty collection otherwise an empty 'in' predicate will be generated which will never match any results
 fun <T, R : Any> KProperty1<T, R?>.`in`(values: Collection<R>): Specification<T> = if (values.isNotEmpty()) spec { path ->
     `in`(path).apply { values.forEach { this.value(it) } }
-} else Specification.where(null)!!
+} else Specification.where(null)
 
 // Comparison
 fun <T> KProperty1<T, Number?>.le(x: Number) = spec { le(it, x) }
@@ -65,7 +65,7 @@ fun <T> KProperty1<T, String?>.notLike(x: String): Specification<T> = spec { not
 fun <T> KProperty1<T, String?>.notLike(x: String, escapeChar: Char): Specification<T> = spec { notLike(it, x, escapeChar) }
 
 // And
-infix fun <T> Specification<T>.and(other: Specification<T>): Specification<T> = this.and(other)!!
+infix fun <T> Specification<T>.and(other: Specification<T>): Specification<T> = this.and(other)
 
 inline fun <reified T> and(vararg specs: Specification<T>?): Specification<T> {
     return and(specs.toList())
@@ -76,7 +76,7 @@ inline fun <reified T> and(specs: Iterable<Specification<T>?>): Specification<T>
 }
 
 // Or
-infix fun <T> Specification<T>.or(other: Specification<T>): Specification<T> = this.or(other)!!
+infix fun <T> Specification<T>.or(other: Specification<T>): Specification<T> = this.or(other)
 
 inline fun <reified T> or(vararg specs: Specification<T>?): Specification<T> {
     return or(specs.toList())
@@ -96,4 +96,4 @@ inline fun <reified T> combineSpecification(specs: Iterable<Specification<T>?>,
 }
 
 // Empty Specification
-inline fun <reified T> emptySpecification(): Specification<T> = Specification.where(null)!!
+inline fun <reified T> emptySpecification(): Specification<T> = Specification.where(null)

--- a/src/test/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSLTest.kt
+++ b/src/test/kotlin/au/com/console/jpaspecificationdsl/JPASpecificationDSLTest.kt
@@ -22,9 +22,9 @@ open class JPASpecificationDSLTest {
     @Autowired
     lateinit var tvShowRepo: TvShowRepository
 
-    lateinit var hemlockGrove: TvShow
-    lateinit var theWalkingDead: TvShow
-    lateinit var betterCallSaul: TvShow
+    private lateinit var hemlockGrove: TvShow
+    private lateinit var theWalkingDead: TvShow
+    private lateinit var betterCallSaul: TvShow
 
     @BeforeEach
     fun setup() {
@@ -72,7 +72,7 @@ open class JPASpecificationDSLTest {
      * A single TvShowQuery is equivalent to an AND of all supplied criteria.
      * Note: any criteria that is null will be ignored (not included in the query).
      */
-    fun TvShowQuery.toSpecification(): Specification<TvShow> = and(
+    private fun TvShowQuery.toSpecification(): Specification<TvShow> = and(
             hasName(name),
             availableOnNetflix(availableOnNetflix),
             hasKeywordIn(keywords),
@@ -82,7 +82,7 @@ open class JPASpecificationDSLTest {
     /**
      * A collection of TvShowQueries is equivalent to an OR of all the queries in the collection.
      */
-    fun Iterable<TvShowQuery>.toSpecification(): Specification<TvShow> = or(
+    private fun Iterable<TvShowQuery>.toSpecification(): Specification<TvShow> = or(
             map { query -> query.toSpecification() }
     )
 

--- a/src/test/kotlin/au/com/console/jpaspecificationdsl/TvShowRepository.kt
+++ b/src/test/kotlin/au/com/console/jpaspecificationdsl/TvShowRepository.kt
@@ -4,10 +4,10 @@ import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
-import javax.persistence.OneToMany
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
 
 @Repository
 interface TvShowRepository : CrudRepository<TvShow, Int>, JpaSpecificationExecutor<TvShow>
@@ -21,7 +21,7 @@ data class TvShow(
         val synopsis: String = "",
         val availableOnNetflix: Boolean = false,
         val releaseDate: String? = null,
-        @OneToMany(cascade = kotlin.arrayOf(javax.persistence.CascadeType.ALL))
+        @OneToMany(cascade = [jakarta.persistence.CascadeType.ALL])
         val starRatings: Set<StarRating> = emptySet())
 
 @Entity


### PR DESCRIPTION
Part of #https://github.com/OneSpark-Insurance/.github-private/issues/1409

## High Level Summary

1. Update deps to spring 3 version 3.0.9 since that is what at least the payment-service is going to be migrating today on the first round. This might be bumped to a later version as more updates come if required.
1. Required namespace from javax.* to jakarta.* changed
1. IDE warnings resolved (making functions private, remove redundant !!)
1. Tests updated

## Pull request checklist

Please check if your PR fulfills the following requirements:
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Build (`make clean build`) was run locally and any changes were pushed
* [x] Tests  (`make clean test`) have passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:
* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, renaming)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] Documentation content changes
* [ ] Other (please describe): 

## Does this introduce a breaking change?

* [ ] Yes (please describe): 
* [x] No

## Other information
