### PR TITLE
♻️ (prepping-gradle9.0): Move convention props to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compile("au.com.console:kotlin-jpa-specification-dsl:3.0.0")
+    compile("au.com.console:kotlin-jpa-specification-dsl:4.0.0")
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,15 +3,19 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
-group 'au.com.console'
+ext {
+    group 'au.com.console'
+}
 
 repositories {
     mavenCentral()
     gradlePluginPortal()
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 dependencies {
     api 'org.jetbrains.kotlin:kotlin-reflect'


### PR DESCRIPTION
The payment-service build raises an error when moving it to Gradle 9 because of https://docs.gradle.org/8.6/userguide/upgrading_version_8.html#java_convention_deprecation within this jar.

Moving the offending configs to use the extension mechanism